### PR TITLE
Potential fix for code scanning alert no. 73: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/vieira-wilson/juice-shop-ada-1497/security/code-scanning/73](https://github.com/vieira-wilson/juice-shop-ada-1497/security/code-scanning/73)

To fix the code injection vulnerability, we must avoid passing user input directly into JavaScript code via the `$where` clause. The safest way is to construct your query using standard query operators instead of `$where`, such as `{ orderId: id }`. In this case, you only need to look up orders using the value of `orderId`, and there is no need for JavaScript-based filtering. Therefore, change:
```js
db.ordersCollection.find({ $where: `this.orderId === '${id}'` })
```
to:
```js
db.ordersCollection.find({ orderId: id })
```
This approach is safe since it does not involve evaluating user input as code. No extra imports are needed. Only lines within the provided code snippet should be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
