### PR TITLE
Potential fix for code scanning alert no. 65: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -19,6 +19,9 @@ class ErrorWithParent extends Error {
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    if (typeof criteria !== 'string') {
+      criteria = ''
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/vieira-wilson/juice-shop-ada-1497/security/code-scanning/65](https://github.com/vieira-wilson/juice-shop-ada-1497/security/code-scanning/65)

To fix the vulnerability without changing existing functionality, you should ensure that `criteria` is always a string before performing any string operations on it. The best way is to insert a runtime type check immediately after assigning from `req.query.q`, converting arrays (and other unexpected types) to an empty string or joining arrays into a single string (if desired), similar to the secure pattern shown in the background example. This change should be made in the body of the `searchProducts` function in routes/search.ts, specifically in the section where `criteria` is set (lines 21–22). No additional methods or definitions are needed, and no imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
