### PR TITLE
Potential fix for code scanning alert no. 64: Type confusion through parameter tampering

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -133,6 +133,9 @@ export const redirectAllowlist = new Set([
 ])
 
 export const isRedirectAllowed = (url: string) => {
+  if (typeof url !== 'string') {
+    return false
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge


### PR DESCRIPTION
Potential fix for [https://github.com/vieira-wilson/juice-shop-ada-1497/security/code-scanning/64](https://github.com/vieira-wilson/juice-shop-ada-1497/security/code-scanning/64)

To mitigate this vulnerability, the best approach is to ensure that only string values are passed into `isRedirectAllowed` and processed there, rejecting arrays and other non-string types. Specifically, you should add a runtime check at the start of the `isRedirectAllowed` function to verify that the argument is a string—if it is not, immediately return false, preventing redirection from proceeding with malformed or tampered parameters. The check should be placed inside `lib/insecurity.ts`, in the `isRedirectAllowed` function, before any logic that uses `url.includes`. No new imports or helper functions are needed for this simple type guard.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
